### PR TITLE
Fix synchronization bugs

### DIFF
--- a/Firmware/Library/Library.cproj
+++ b/Firmware/Library/Library.cproj
@@ -168,6 +168,9 @@
     <Compile Include="hwbp_sync.c">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="hwbp_sync.h">
+      <SubType>compile</SubType>
+    </Compile>
   </ItemGroup>
   <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
 </Project>

--- a/Firmware/Library/hwbp_core.c
+++ b/Firmware/Library/hwbp_core.c
@@ -545,9 +545,10 @@ ISR(TCC1_CCA_vect, ISR_NAKED)
 {   
 	SYNC_TRIGGER_TIMER;
     
+    TCC1_CCA += _500us_cca_values[_500us_cca_index++ & 0x07];
+	
     core_callback_t_before_exec();
-
-	TCC1_CCA += _500us_cca_values[_500us_cca_index++ & 0x07];	
+	
 
 	//core_send_event(ADD_R_TIMESTAMP_SECOND);
 

--- a/Firmware/Library/hwbp_sync.c
+++ b/Firmware/Library/hwbp_sync.c
@@ -197,15 +197,6 @@ void trigger_sync_timer (void)
 {
     uint8_t byte = USART_RX_BYTE;
     
-    if (byte == 0xAA)
-    {
-        state = 0;
-    }        
-    else if (byte == 0xAF)
-    {
-        state = 1;
-    }
-    
     switch (state)        
     {
         case 0:

--- a/Firmware/Library/hwbp_sync.c
+++ b/Firmware/Library/hwbp_sync.c
@@ -167,8 +167,8 @@ void trigger_sync_timer (void)
 #if defined(__AVR_ATxmega16A4U__)
 #else
     static uint8_t state = 0;
-    static uint8_t converging = 7;
-    uint8_t device_lost_sync_counter = 0;
+    static uint8_t converging;
+    uint8_t device_lost_sync_counter = 254;	// Needs to be lower than 255
 #endif
 
 #if defined(__AVR_ATxmega32A4U__)
@@ -231,36 +231,45 @@ void trigger_sync_timer (void)
         case 5:
             *((uint8_t*)(&sync_timestamp) + 3) = byte;
             state = 0;
-            
-            // CCA values:
-            // 31217
-            // 31233
-            // (the average is 31225)
-            
-            if (device_lost_sync_counter >= 10)
-                converging = 7;
+           
+			// We are here 98.2 +/-0.3 us after the last byte starts
+			// This means that we are 672 - 98.2 = 573.8 before the second elapses
+			// 573.8 us before the second elapses means that CCA should be equal to (1s - 573.8us) / 32us = 31232.1
+			// Let's use CCA = 31232
+		               
+			// The last CCA written is 31233 = 0.999456 us, i.e., 544 us before the second elapses
+		               
+			// The 'device_lost_sync_counter' is incremented externally on every timer overflow, i.e., when each second elapses
+			// If the sync is lost for more than 10 seconds,
+		   
+		    
+            if (device_lost_sync_counter >= 5)
+			{
+				// If the sync is lost for more than 5 seconds, restart the sync mechanism by converging
+                
+				converging = 12;	// 12*32us = 384 us away from the next 
+				TCC1_CNT = 31231 - converging;
+				TCC1_CCA = 31233;
+				
+				device_lost_sync_counter = 0;
+				
+			}
             else
+			{				
                 device_lost_sync_counter = 0;
+				
+                if (converging)
+					converging -= 2;
+							
+				if (TCC1_CNT < TCC1_CCA)
+				{
+					TCC1_CNT = 31231 - converging;
+					toggle_io(PORTD, 6);
+				}
+			}
             
-            /*
-            TCC1_CTRLA = TC_CLKSEL_OFF_gc;
-            TCC1_CTRLFSET = TC_CMD_RESET_gc;
-            TCC1_PER = 31250;
-            TCC1_INTCTRLA = INT_LEVEL_LOW;
-            */
-            
-            TCC1_CNT = 31225 - converging;
-            TCC1_CCA = 31233;
 			
 			clock_was_just_updated_externaly = true;
-            
-            /*
-            TCC1_CTRLA = TIMER_PRESCALER_DIV1024;
-            TCC1_INTCTRLB = INT_LEVEL_LOW;
-            */
-            
-            if (converging)
-                converging--;
             
             *core_timestamp_pointer = sync_timestamp;
             

--- a/Firmware/Library/hwbp_sync.c
+++ b/Firmware/Library/hwbp_sync.c
@@ -131,11 +131,7 @@ void trigger_sync_timer (void)
 /************************************************************************/
 #if defined(__AVR_ATxmega16A4U__)
     ISR(TCD0_OVF_vect, ISR_NAKED)
-    {
-        if ((*timestamp_B0 == 0xAA) && (*timestamp_B1 == 0xAF)) reti();
-        if ((*timestamp_B1 == 0xAA) && (*timestamp_B2 == 0xAF)) reti();
-        if ((*timestamp_B2 == 0xAA) && (*timestamp_B3 == 0xAF)) reti();
-        
+    {   
         switch (timestamp_tx_counter)
         {
             case 1:

--- a/Firmware/Library/hwbp_sync.h
+++ b/Firmware/Library/hwbp_sync.h
@@ -37,7 +37,7 @@ void trigger_sync_timer (void);
 #if defined(__AVR_ATxmega16A4U__)
     #define INCREASE_LOST_SYNC_COUNTER
 #else
-    #define INCREASE_LOST_SYNC_COUNTER device_lost_sync_counter++
+    #define INCREASE_LOST_SYNC_COUNTER if(++device_lost_sync_counter == 255) device_lost_sync_counter = 254
 #endif
 
 


### PR DESCRIPTION
This PR fixes two synchronization issues:
- **(1)** Time travel of hundreds of milliseconds every few hours.
- **(2)** Deviation of timestamp listeners.

**(1)** Fixes the erroneous protection of the timestamp header.

**(2)** Fixes the deviation found of ~200 us between the timestamp generator and the timestamp listeners.
The current deviation is now a delay to the timestamp generator of 22 +/- 16 us.